### PR TITLE
Release/2.2.6

### DIFF
--- a/includes/blocks/safe-svg/block.json
+++ b/includes/blocks/safe-svg/block.json
@@ -48,6 +48,5 @@
     }
   },
   "editorScript": "file:../../../dist/safe-svg-block.js",
-  "editorStyle": "file:../../../dist/safe-svg-block-index.css",
   "style": "file:../../../dist/safe-svg-block-frontend.css"
 }

--- a/includes/blocks/safe-svg/block.json
+++ b/includes/blocks/safe-svg/block.json
@@ -5,7 +5,7 @@
   "description": "Display the SVG icon",
   "textdomain": "safe-svg",
   "name": "safe-svg/svg-icon",
-  "category": "safe-svg-blocks",
+  "category": "media",
   "attributes": {
     "svgURL": {
       "type": "string",
@@ -14,9 +14,6 @@
     "type": {
       "type": "string",
       "default": "full"
-    },
-    "alignment": {
-      "type": "string"
     },
     "imageID": {
       "type": "number",
@@ -39,6 +36,7 @@
     }
   },
   "supports": {
+    "align": [ "left", "center", "right", "wide", "full" ],
     "html": false,
     "color": {
       "text": true,
@@ -50,5 +48,6 @@
     }
   },
   "editorScript": "file:../../../dist/safe-svg-block.js",
+  "editorStyle": "file:../../../dist/safe-svg-block-index.css",
   "style": "file:../../../dist/safe-svg-block-frontend.css"
 }

--- a/includes/blocks/safe-svg/edit.js
+++ b/includes/blocks/safe-svg/edit.js
@@ -193,7 +193,7 @@ const SafeSvgBlockEdit = ( props ) => {
 						className="safe-svg-inside"
 					>
 						<ReactSVG src={svgURL} beforeInjection={(svg) => {
-							svg.setAttribute( 'width', `${dimensionWidth}px` );
+							svg.setAttribute( 'width', `${dimensionWidth}` );
 							svg.setAttribute( 'height', `${dimensionHeight}` );
 						}} />
 					</div>

--- a/includes/blocks/safe-svg/edit.js
+++ b/includes/blocks/safe-svg/edit.js
@@ -18,6 +18,7 @@ import {
 } from '@wordpress/block-editor';
 import PropTypes from 'prop-types';
 import { ReactSVG } from 'react-svg'
+import './editor.scss';
 
 /**
  * Edit component.
@@ -64,10 +65,6 @@ const SafeSvgBlockEdit = ( props ) => {
 	const newClassName = className.replace(/has-[\w-]*-color|has-background/g, '').trim();
 	containerBlockProps.className = newClassName;
 
-	// Add the width and height to enforce dimensions and to keep parity with the frontend.
-	style.width = `${dimensionWidth}px`;
-	style.height = `${dimensionHeight}px`;
-
 	const ALLOWED_MEDIA_TYPES = [ 'image/svg+xml' ];
 
 	const onSelectImage = media => {
@@ -102,9 +99,11 @@ const SafeSvgBlockEdit = ( props ) => {
 	}
 
 	const onChange = (dimensionSizes) => {
-		if( !dimensionSizes.width && !dimensionSizes.height ) {
-			dimensionSizes.width = parseInt( imageSizes[type].width );
-			dimensionSizes.height = parseInt( imageSizes[type].height );
+		if( null === dimensionSizes.width ) {
+			dimensionSizes.width = 0;
+		}
+		if( null === dimensionSizes.height ) {
+			dimensionSizes.height = 0;
 		}
 		setAttributes({
 			dimensionWidth: dimensionSizes.width ?? dimensionWidth,
@@ -163,9 +162,6 @@ const SafeSvgBlockEdit = ( props ) => {
 							onChangeImage={onChangeImage} />
 					</PanelBody>
 				</InspectorControls><BlockControls>
-						<AlignmentToolbar
-							value={alignment}
-							onChange={(newVal) => setAttributes({ alignment: newVal })} />
 					</BlockControls><BlockControls>
 						<MediaReplaceFlow
 							mediaId={imageID}
@@ -198,7 +194,8 @@ const SafeSvgBlockEdit = ( props ) => {
 						className="safe-svg-inside"
 					>
 						<ReactSVG src={svgURL} beforeInjection={(svg) => {
-							svg.setAttribute( 'style', `width: ${dimensionWidth}px; height: ${dimensionHeight}px;` );
+							svg.setAttribute( 'width', `${dimensionWidth}px` );
+							svg.setAttribute( 'height', `${dimensionHeight}` );
 						}} />
 					</div>
 				</div>

--- a/includes/blocks/safe-svg/edit.js
+++ b/includes/blocks/safe-svg/edit.js
@@ -18,7 +18,6 @@ import {
 } from '@wordpress/block-editor';
 import PropTypes from 'prop-types';
 import { ReactSVG } from 'react-svg'
-import './editor.scss';
 
 /**
  * Edit component.

--- a/includes/blocks/safe-svg/frontend.scss
+++ b/includes/blocks/safe-svg/frontend.scss
@@ -1,15 +1,33 @@
-.safe-svg-cover {
-    text-align: center;
+.wp-block-safe-svg-svg-icon	{
+	svg {
+		display: block;
+		height: auto;
+		max-block-size: 100%;
+		max-inline-size: 100%;
+	}
 
-    .safe-svg-inside {
-        display: inline-block;
-        max-width: 100%;
-    }
+	&.alignfull,
+	&.alignwide {
+		svg {
+			width: 100%;
+		}
+	}
 
-    svg {
-        height: 100%;
-        max-height: 100%;
-        max-width: 100%;
-        width: 100%;
-    }
+	&.aligncenter,
+	&.alignleft,
+	&.alignright {
+		display: table;
+	}
+
+	&.aligncenter {
+		text-align: center;
+	}
+
+	&.alignleft {
+		text-align: left;
+	}
+
+	&.alignright {
+		text-align: right;
+	}
 }

--- a/includes/blocks/safe-svg/frontend.scss
+++ b/includes/blocks/safe-svg/frontend.scss
@@ -1,6 +1,6 @@
 .wp-block-safe-svg-svg-icon	{
 	svg {
-		display: block;
+		vertical-align: middle;
 		height: auto;
 		max-block-size: 100%;
 		max-inline-size: 100%;

--- a/includes/blocks/safe-svg/frontend.scss
+++ b/includes/blocks/safe-svg/frontend.scss
@@ -18,16 +18,4 @@
 	&.alignright {
 		display: table;
 	}
-
-	&.aligncenter {
-		text-align: center;
-	}
-
-	&.alignleft {
-		text-align: left;
-	}
-
-	&.alignright {
-		text-align: right;
-	}
 }

--- a/includes/blocks/safe-svg/register.php
+++ b/includes/blocks/safe-svg/register.php
@@ -92,7 +92,16 @@ function render_block_callback( $attributes ) {
 		)
 	);
 
-	$inside_style = render_inline_css( $inside_style );
+	/**
+	 * The inside style.
+	 * 
+	 * Allows a user to adjust the inline svg inside style attribute.
+	 * 
+	 * @param string The style attribute.
+	 * 
+	 * @since 2.5.6
+	 */	
+	$inside_style = apply_filters( 'safe_svg_inside_inline_style', render_inline_css( $inside_style ) );
 
 	/**
 	 * The wrapper markup.

--- a/includes/blocks/safe-svg/register.php
+++ b/includes/blocks/safe-svg/register.php
@@ -57,6 +57,17 @@ function render_block_callback( $attributes ) {
 	}
 
 	/**
+	 * The cover style.
+	 * 
+	 * Allows a user to adjust the inline svg cover style attribute .
+	 * 
+	 * @param string The style attribute.
+	 * 
+	 * @since 2.5.6
+	 */	
+	$cover_style = apply_filters( 'safe_svg_cover_inline_style', isset( $attributes['alignment'] ) ? 'text-align: ' . $attributes['alignment'] : 'text-align: left');
+	
+	/**
 	 * The wrapper markup.
 	 *
 	 * Allows a user to adjust the inline svg wrapper markup.
@@ -71,10 +82,10 @@ function render_block_callback( $attributes ) {
 	return apply_filters(
 		'safe_svg_inline_markup',
 		sprintf(
-			'<div class="wp-block-safe-svg-svg-icon safe-svg-cover" style="text-align: %s;">
+			'<div class="wp-block-safe-svg-svg-icon safe-svg-cover"%s>
 				<div class="safe-svg-inside%s" style="width: %spx; height: %spx; background-color: var(--wp--preset--color--%s); color: var(--wp--preset--color--%s); padding-top: %s; padding-right: %s; padding-bottom: %s; padding-left: %s; margin-top: %s; margin-right: %s; margin-bottom: %s; margin-left: %s;">%s</div>
 			</div>',
-			isset( $attributes['alignment'] ) ? esc_attr( $attributes['alignment'] ) : 'left',
+			empty( $cover_style ) ? '' : ' style="' . esc_attr( $cover_style ) . '"',
 			empty( $class_name ) ? '' : ' ' . esc_attr( $class_name ),
 			isset( $attributes['dimensionWidth'] ) ? esc_attr( $attributes['dimensionWidth'] ) : '',
 			isset( $attributes['dimensionHeight'] ) ? esc_attr( $attributes['dimensionHeight'] ) : '',

--- a/includes/blocks/safe-svg/register.php
+++ b/includes/blocks/safe-svg/register.php
@@ -70,11 +70,17 @@ function render_block_callback( $attributes ) {
 	$inside_style = array();
 
 	if ( isset( $attributes['style']['spacing']['padding'] ) ) {
-		$inside_style = add_css_property_prefix( $attributes['style']['spacing']['padding'], 'padding' );
+		$inside_style = array_merge(
+			$inside_style,
+			add_css_property_prefix( $attributes['style']['spacing']['padding'], 'padding' )
+		);
 	}
 	
 	if ( isset( $attributes['style']['spacing']['margin'] ) ) {
-		$inside_style = add_css_property_prefix( $attributes['style']['spacing']['margin'], 'margin' );
+		$inside_style = array_merge (
+			$inside_style,
+			add_css_property_prefix( $attributes['style']['spacing']['margin'], 'margin' )
+		);
 	}
 
 	$inside_style = array_map(

--- a/includes/blocks/safe-svg/register.php
+++ b/includes/blocks/safe-svg/register.php
@@ -65,17 +65,6 @@ function render_block_callback( $attributes ) {
 	if ( isset( $attributes['className'] ) ) {
 		$class_name = $class_name . ' ' . $attributes['className'];
 	}
-
-	/**
-	 * The cover style.
-	 * 
-	 * Allows a user to adjust the inline svg cover style attribute .
-	 * 
-	 * @param string The style attribute.
-	 * 
-	 * @since 2.5.6
-	 */	
-	$cover_style = apply_filters( 'safe_svg_cover_inline_style', isset( $attributes['alignment'] ) ? 'text-align: ' . $attributes['alignment'] : 'text-align: left');
 	
 	$inside_style = array();
 
@@ -132,10 +121,10 @@ function render_block_callback( $attributes ) {
 	return apply_filters(
 		'safe_svg_inline_markup',
 		sprintf(
-			'<div class="wp-block-safe-svg-svg-icon safe-svg-cover"%s>
+			'<div class="wp-block-safe-svg-svg-icon safe-svg-cover%s">
 				<div class="safe-svg-inside%s"%s>%s</div>
 			</div>',
-			empty( $cover_style ) ? '' : ' style="' . esc_attr( $cover_style ) . '"',
+			isset( $attributes['align'] ) ? ' align' . $attributes['align'] : '',
 			empty( $class_name ) ? '' : ' ' . esc_attr( $class_name ),
 			empty( $inside_style ) ? '' : ' style="' . esc_attr( $inside_style ) . '"',
 			$contents

--- a/includes/blocks/safe-svg/register.php
+++ b/includes/blocks/safe-svg/register.php
@@ -7,6 +7,8 @@
 
 namespace SafeSvg\Blocks\SafeSvgBlock;
 
+use WP_HTML_Tag_Processor;
+
 /**
  * Register the block
  */
@@ -39,6 +41,14 @@ function render_block_callback( $attributes ) {
 	// If we couldn't get the contents of the file, empty string again.
 	if ( ! $contents = file_get_contents( get_attached_file( $attributes['imageID'] ) ) ) { // phpcs:ignore
 		return '';
+	}
+
+	$contents = new WP_HTML_Tag_Processor( $contents );
+		
+	if ( $contents->next_tag( 'svg' ) ) {
+		$contents->set_attribute( 'width', isset( $attributes['dimensionWidth'] ) ? esc_attr( $attributes['dimensionWidth'] . 'px' ) : 'auto' );
+		$contents->set_attribute( 'height', isset( $attributes['dimensionHeight'] ) ? esc_attr( $attributes['dimensionHeight'] . 'px' ) : 'auto' );
+		$contents->get_updated_html();
 	}
 
 	/**
@@ -91,8 +101,6 @@ function render_block_callback( $attributes ) {
 	$inside_style = array_merge(
 		$inside_style,
 		array(
-			'width'            => isset( $attributes['dimensionWidth'] ) ? esc_attr( $attributes['dimensionWidth'] . 'px' ) : '',
-			'height'           => isset( $attributes['dimensionHeight'] ) ? esc_attr( $attributes['dimensionHeight'] . 'px' ) : '',
 			'background-color' => ( isset( $attributes['backgroundColor'] ) ? esc_attr( 'var(--wp--preset--color--' . $attributes['backgroundColor'] . ')' ) : '' ) ?: ( isset( $attributes['style']['color']['background'] ) ? esc_attr( $attributes['style']['color']['background'] ) : '' ),
 			'color'            => ( isset( $attributes['textColor'] ) ? esc_attr( 'var(--wp--preset--color--' . $attributes['textColor'] . ')' ) : '' ) ?: ( isset( $attributes['style']['color']['text'] ) ? esc_attr( $attributes['style']['color']['text'] ) : '' ),
 		)

--- a/includes/blocks/safe-svg/register.php
+++ b/includes/blocks/safe-svg/register.php
@@ -52,6 +52,10 @@ function render_block_callback( $attributes ) {
 	 */
 	$class_name = apply_filters( 'safe_svg_inline_class', 'safe-svg-inline' );
 
+	if ( isset( $attributes['className'] ) ) {
+		$class_name = $class_name . ' ' . $attributes['className'];
+	}
+
 	/**
 	 * The wrapper markup.
 	 *
@@ -68,11 +72,10 @@ function render_block_callback( $attributes ) {
 		'safe_svg_inline_markup',
 		sprintf(
 			'<div class="wp-block-safe-svg-svg-icon safe-svg-cover" style="text-align: %s;">
-				<div class="safe-svg-inside %s%s" style="width: %spx; height: %spx; background-color: var(--wp--preset--color--%s); color: var(--wp--preset--color--%s); padding-top: %s; padding-right: %s; padding-bottom: %s; padding-left: %s; margin-top: %s; margin-right: %s; margin-bottom: %s; margin-left: %s;">%s</div>
+				<div class="safe-svg-inside%s" style="width: %spx; height: %spx; background-color: var(--wp--preset--color--%s); color: var(--wp--preset--color--%s); padding-top: %s; padding-right: %s; padding-bottom: %s; padding-left: %s; margin-top: %s; margin-right: %s; margin-bottom: %s; margin-left: %s;">%s</div>
 			</div>',
 			isset( $attributes['alignment'] ) ? esc_attr( $attributes['alignment'] ) : 'left',
-			esc_attr( $class_name ),
-			isset( $attributes['className'] ) ? ' ' . esc_attr( $attributes['className'] ) : '',
+			empty( $class_name ) ? '' : ' ' . esc_attr( $class_name ),
 			isset( $attributes['dimensionWidth'] ) ? esc_attr( $attributes['dimensionWidth'] ) : '',
 			isset( $attributes['dimensionHeight'] ) ? esc_attr( $attributes['dimensionHeight'] ) : '',
 			isset( $attributes['backgroundColor'] ) ? esc_attr( $attributes['backgroundColor'] ) : '',


### PR DESCRIPTION
### What Was Accomplished
- Updated render function to prevent empty CSS properties from appearing in the output
- Removed `text-align` support
- Added support for block alignment - same as image blocks
- Added width and height attributes to the SVG element

### How It Was Tested
- [x] Locally

### How To Test
- Inline SVG block behaves like an image:
  - Left, right, and center alignments work as expected
  - Inline SVGs fill the entire container width on `alignwide` and `alignfull`
  - Inline SVGs don't go past a set `flex-basis` size
    - Note that images didn't respect the `flex-basis` height size for stack blocks, which also occurs for inline SVG blocks
- Inline SVG looks similar in the editor and on the frontend